### PR TITLE
Add fixes absent in previous PR

### DIFF
--- a/assignment1/task2a.py
+++ b/assignment1/task2a.py
@@ -89,7 +89,7 @@ def gradient_approximation_test(model: BinaryModel, X: np.ndarray, Y: np.ndarray
         difference = gradient_approximation - model.grad[i, 0]
         assert abs(difference) <= epsilon**2,\
             f"Calculated gradient is incorrect. " \
-            f"Approximation: {gradient_approximation}, actual gradient: {model.grad[i,0]}\n" \
+            f"Approximation: {gradient_approximation}, actual gradient: {model.grad[i, 0]}\n" \
             f"If this test fails there could be errors in your cross entropy loss function, " \
             f"forward function or backward function"
 

--- a/assignment1/task4a.py
+++ b/assignment1/task4a.py
@@ -12,7 +12,8 @@ def cross_entropy_loss(targets: np.ndarray, outputs: np.ndarray):
     Returns:
         Cross entropy error (float)
     """
-    assert targets.shape == outputs.shape
+    assert targets.shape == outputs.shape,\
+        f"Targets shape: {targets.shape}, outputs: {outputs.shape}"
     ce = targets * np.log(outputs)
     raise NotImplementedError
 
@@ -49,7 +50,8 @@ class SoftmaxModel:
         assert targets.shape == outputs.shape,\
             f"Output shape: {outputs.shape}, targets: {targets.shape}"
         self.grad = np.zeros_like(self.w)
-        assert self.grad.shape == self.w.shape
+        assert self.grad.shape == self.w.shape,\
+            f"Grad shape: {self.grad.shape}, w: {self.w.shape}"
 
     def zero_grad(self) -> None:
         self.grad = None
@@ -89,7 +91,7 @@ def gradient_approximation_test(model: SoftmaxModel, X: np.ndarray, Y: np.ndarra
             difference = gradient_approximation - model.grad[i, j]
             assert abs(difference) <= epsilon**2,\
                 f"Calculated gradient is incorrect. " \
-                f"Approximation: {gradient_approximation}, actual gradient: {model.grad[i,0]}\n"\
+                f"Approximation: {gradient_approximation}, actual gradient: {model.grad[i, j]}\n"\
                 f"If this test fails there could be errors in your cross entropy loss function, " \
                 f"forward function or backward function"
 


### PR DESCRIPTION
Somewhat embarrasingly, I overlooked two asserts with missing messages
in previous pull request.
Also, `gradient_approximation_test()` in task4a.py would correctly compare
with `grad[i, j]`, but would _incorrectly_ print the value of `grad[i, 0]`,
leading to confusion and difficulty in debugging. This has been fixed.