### PR TITLE
Download COCO-files, and submit coco-file results

### DIFF
--- a/assignment4/SSD/configs/train_tdt4265.yaml
+++ b/assignment4/SSD/configs/train_tdt4265.yaml
@@ -8,8 +8,8 @@ MODEL:
 INPUT:
     IMAGE_SIZE: 300
 DATASETS:
-    TRAIN: ("tdt4265_train",)
-    TEST: ("tdt4265_val", )
+    TRAIN: ("coco_traffic_train",)
+    TEST: ("coco_traffic_val", )
 SOLVER:
     MAX_ITER: 120000
     LR_STEPS: [80000, 100000]

--- a/assignment4/SSD/make_train_val_split.py
+++ b/assignment4/SSD/make_train_val_split.py
@@ -1,0 +1,30 @@
+import json
+
+
+def train_val_split(master_source, train_split_path, val_split_path, train_val_ratio = 0.8):
+    with open(master_source, "r") as json_file:
+        master = json.load(json_file)
+
+    train = {k: v for k,v in master.items()}
+    train["annotations"] = master["annotations"][0:int(train_val_ratio*len(master["annotations"]))]
+    highest_image_id = train["annotations"][-1]["image_id"]
+    images = []
+    for image in master["images"]:
+        if image["id"] <= highest_image_id:
+            images.append(image)
+    train["images"] = images
+    with open(train_split_path, "w") as json_file:
+        json.dump(train, json_file)
+
+
+    test = {k : v for k,v in master.items()}
+    test["annotations"] = master["annotations"][int(train_val_ratio*len(master["annotations"])):]
+    lowest_image_id = test["annotations"][0]["image_id"]
+    images = []
+    for image in master["images"]:
+        if image["id"] >= lowest_image_id:
+            images.append(image)
+    test["images"] = images
+    with open(val_split_path, "w") as json_file:
+        json.dump(test, json_file)
+

--- a/assignment4/SSD/ssd/config/path_catlog.py
+++ b/assignment4/SSD/ssd/config/path_catlog.py
@@ -79,6 +79,21 @@ class DatasetCatalog:
         'tdt4265_test': {
             'data_dir': 'tdt4265/test',
             'split': 'test'
+        },
+        "coco_traffic_train": {
+            "data_dir": "train/images",
+            "ann_file": "labels_train.json",
+            "split" : "train"
+        },
+        "coco_traffic_val" : {
+            "data_dir": "train/images",
+            "ann_file": "val_split.json",
+            "split" : "val"
+        },
+        "coco_traffic_test" : {
+            "data_dir": "test/images",
+            "ann_file": "empty_test.json",
+            "split" : "test"
         }
 
     }

--- a/assignment4/SSD/update_tdt4265_dataset.py
+++ b/assignment4/SSD/update_tdt4265_dataset.py
@@ -6,7 +6,7 @@ import zipfile
 import tqdm
 
 
-zip_url = "https://drive.google.com/file/d/1gjNk2vubi7-4Tq8bZS95lffYhvoitpT9/view?usp=sharing"
+zip_url = ""
 dataset_path = pathlib.Path("datasets", "tdt4265")
 
 
@@ -70,10 +70,12 @@ def download_labels(request_wrapper):
     if status_code != 200:
         print("Failure on download of dataset. Contact a TA.")
         exit()
-    labels = json.loads(response.text)
-    label_path = dataset_path.joinpath("train", "labels.json")
-    with open(label_path, "w") as fp:
-        json.dump(labels, fp)
+    zip_path = dataset_path.joinpath("labels.zip")
+    with open(zip_path, 'wb') as fd:
+        for chunk in response.iter_content(chunk_size=512):
+            fd.write(chunk)
+    with zipfile.ZipFile(zip_path) as f:
+        f.extractall(dataset_path)
     print("Labels downloaded.")
 
 


### PR DESCRIPTION
Endringer for å gå fra TDT-format til COCO-format. Jeg har ikke fått testet alt end-to-end med hvordan mappe-strukturen blir og sånt, men jeg har unit-testet nedlasting og opplasting. Begge deler er kompatible med nåværende versjon av CVAT. Ting som må sees på er hvordan mappestrukturen ender opp for nedlastede labels, og om vi automatisk skal dele opp treningsdataen i validation og train sett i samme slengen som vi laster labelsene ned.